### PR TITLE
fix(src/components): resolve variant request load failure

### DIFF
--- a/src/components/font-config.js
+++ b/src/components/font-config.js
@@ -26,6 +26,7 @@ const FontConfig = ({
       value={variant}
       options={variants}
       onSelect={onVariantSelect}
+      familyName={family}
       disabled={!!sidebar}
     />
   </div>

--- a/src/components/font-tools.js
+++ b/src/components/font-tools.js
@@ -10,7 +10,12 @@ const FontTools = ({ title, family, variant, variants, sidebar }) => (
       active={title === sidebar}
       disabled={sidebar && title !== sidebar}
     />
-    <VariantSelect value={variant} options={variants} disabled={!!sidebar} />
+    <VariantSelect
+      value={variant}
+      options={variants}
+      familyName={family}
+      disabled={!!sidebar}
+    />
   </div>
 )
 

--- a/src/components/variant-select.js
+++ b/src/components/variant-select.js
@@ -5,8 +5,8 @@ import loadWebFonts from "../utilities/load-web-fonts"
 
 const VariantSelect = ({ value, options, onSelect, familyName }) => {
   useEffect(() => {
-    loadWebFonts([`${familyName}:${value}`])
-  }, [value])
+    loadWebFonts([`${familyName ? familyName : "Roboto"}:${value}`])
+  }, [familyName, value])
 
   const handleChange = event => onSelect(event.target.value)
 
@@ -28,7 +28,7 @@ VariantSelect.propTypes = {
   value: PropTypes.string,
   options: PropTypes.arrayOf(PropTypes.string),
   onSelect: PropTypes.func,
-  familyName: PropTypes.string,
+  familyName: PropTypes.string.isRequired,
 }
 
 VariantSelect.defaultProps = {


### PR DESCRIPTION
Update props passed to VariantSelect to include `familyName` as it was missing in requests to the GoogleFonts API

- fix #302